### PR TITLE
Fix go.mod syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jsdidierlaurent/echo-middleware
 
-go 1.11.5
+go 1.11
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737


### PR DESCRIPTION
The go version should be "go MAJOR.MINOR".

Fixes the following errors:
  go: errors parsing go.mod:
  /pth/echo-middleware/go.mod:3: usage: go 1.23

More info:
https://groups.google.com/d/msg/golang-nuts/fBD63zkssQI/flupi9jtBAAJ
